### PR TITLE
Simplify API by removing sql building feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SCIM Filter Transpiler
 
-Transpiles Tokenized SCIM v2 Filter into a SQL command. It utilizes https://github.com/di-wu/scim-filter-parser to do the work of parsing a raw filter query parameter. It uses https://github.com/Masterminds/squirrel to do the SQL building.
+Transpiles Tokenized SCIM v2 Filter into a SQL command. It utilizes https://github.com/di-wu/scim-filter-parser to do the work of parsing a raw filter query parameter.
 
 ## Install
 
@@ -23,18 +23,8 @@ parser := NewParser(
     "emails":       "emails.value",
     "emails.type":  "emails.type",
   },
-  // Resource table name
-  "users",
-  // Include any necessary joins
-  []string{"LEFT JOIN emails ON emails.user_id = users.id"},
 )
 
 // Use ToSql if you already have a parsed filter.
-sql, _ := parser.ToSqlFromString(`userName eq "andy@example.com"`, "users.id")
-
-// We can even use Squirrel to query our DB, or use ToSql to get the raw query and params.
-// Builds the following query:
-// SELECT users.id FROM users LEFT JOIN emails ON emails.user_id = users.id WHERE users.username = ?
-// With andy@example.com as the only parameter
-rows, _ := sql.Limit(10).Offset(10).RunWith(db).Query()
+query, params, _ := parser.ToSqlFromString(`userName eq "andy@example.com"`)
 ```

--- a/sql_test.go
+++ b/sql_test.go
@@ -74,15 +74,19 @@ func TestFilterParser(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		parser := NewParser(test.attributeMap, "users", test.joins)
+		parser := NewParser(test.attributeMap)
 
-		sqlQuery, err := parser.ToSqlFromString(test.filter, "distinct on (users.id) users.id")
+		query, params, err := parser.ToSqlFromString(test.filter)
 
 		if err != nil {
 			t.Errorf("Expected to create a filter parser without an error but received an error %v", err)
 		}
 
-		query, params, err := sqlQuery.ToSql()
+		sqlQuery := sq.Select("distinct on (users.id) users.id").
+			From("users").
+			Where(query, params...).
+			JoinClause("LEFT JOIN emails ON emails.user_id = users.id")
+		query, params, err = sqlQuery.ToSql()
 
 		if err != nil {
 			t.Errorf("failed to parse sql query, error %v", err)


### PR DESCRIPTION
Consumers will now just get back the WHERE clause and the params for the
clause to avoid sql injection. This will also allow consumers using an ORM to plug this in and get all of the nice features of an ORM.